### PR TITLE
Make failed tests return exit code 1

### DIFF
--- a/testthat.R
+++ b/testthat.R
@@ -1,3 +1,3 @@
 library(testthat)
 
-test_dir("testthat",stop_on_failure = TRUE)
+test_dir("testthat", reporter = c("check"))


### PR DESCRIPTION
This changes the reporter in test_dir so that failed tests will return exit code
1 when run the command line and correctly result in failure CI tests.