### PR TITLE
Show detailed test output from testthat

### DIFF
--- a/testthat.R
+++ b/testthat.R
@@ -1,3 +1,3 @@
 library(testthat)
 
-test_dir("testthat", reporter = c("check"))
+test_dir("testthat", reporter = c("check", "progress"))


### PR DESCRIPTION
This is more informative output and will preven issues with long running tests
causing timeout issues on Travis.