### PR TITLE
Check correct commit for version bump tags when merging a PR [no version bump]

### DIFF
--- a/update_version.R
+++ b/update_version.R
@@ -7,6 +7,9 @@
 repo <- git2r::repository(".")
 last_commit <- git2r::commits(repo)[[1]]
 current_ver <- semver::parse_version(readLines("version.txt"))
+if (grepl("Merge pull request", last_commit@summary)){
+    last_commit <- git2r::commits(repo)[[2]]
+}
 
 if (grepl("\\[no version bump\\]", last_commit@summary)) {
   new_ver <- current_ver


### PR DESCRIPTION
When a PR is merged the last commit is the merge commit. To check for version
bump tags we need to check the commit that was merged, not the merge commit.
This checks to see if the last commit was a PR merge and if so checks the next
commit back.