### PR TITLE
Fix comma at end of JSON list in .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -109,7 +109,7 @@
       "affiliation": "Saint Louis University",
       "name": "Thomas J. Valone",
       "orcid": "0000-0002-7657-3126"
-    },
+    }
   ],
   "keywords": [
     "ecology",


### PR DESCRIPTION
This was causing the JSON to be invalid and archives to Zenodo to not happen.