### PR TITLE
Fix version bump type detection [no version bump]

### DIFF
--- a/archive.R
+++ b/archive.R
@@ -8,7 +8,6 @@ config <- yaml::yaml.load_file("config.yml")
 
 repo <- git2r::repository(".")
 repo_url <- paste("https://github.com/", config$repo, ".git", sep = "")
-git2r::checkout(repo, branch = "master")
 git2r::remote_add(repo, name = "deploy", url = repo_url)
 cred <- git2r::cred_token("GITHUB_TOKEN")
 
@@ -37,6 +36,7 @@ if (grepl("\\[no version bump\\]", last_commit['summary'])) {
 writeLines(as.character(new_ver), "version.txt")
 
 travis_build <- Sys.getenv("TRAVIS_BUILD_NUMBER")
+git2r::checkout(repo, branch = "master")
 commit_message <- paste("Update data and trigger archive: Travis Build",
                         travis_build,
                         "[skip ci]")


### PR DESCRIPTION
The version bump type can be controlled by keywords in [] in commit messages.
This wasn't working properly because `master` was being checked out too early
to properly detect the commit history for the changes. This moves the `master`
checkout to after the version bump type detection code to avoid the issue.

See also: https://github.com/weecology/livedat/commit/317fdefc10f76ad550a74ba1747e10a0cdd7b1c2