### PR TITLE
Don't attempt to push changes in PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - R -e 'setwd("DataCleaningScripts"); source("update_portal_plots.R"); writeportalplots()'
   - R -e 'setwd("DataCleaningScripts"); source("new_moon_numbers.r"); writenewmoons()'
   - R -e 'setwd("DataCleaningScripts"); source("update_portal_plant_censuses.R"); writecensustable()'
-  - git checkout master
+  - git checkout master #testing
   - Rscript archive.R
   
 after_success:


### PR DESCRIPTION
PRs can't (and shouldn't) push changes to the repository. This should only happen once the PR is
merged. This causes CI builds to fail incorrectly due to a lack of push permissions, so check to see
if the build is a PR before pushing.