### PR TITLE
Improve git and release behavior on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ script:
   - R -e 'setwd("DataCleaningScripts"); source("update_portal_plots.R"); writeportalplots()'
   - R -e 'setwd("DataCleaningScripts"); source("new_moon_numbers.r"); writenewmoons()'
   - R -e 'setwd("DataCleaningScripts"); source("update_portal_plant_censuses.R"); writecensustable()'
-  - git checkout master
   - Rscript archive.R
   
 after_success:

--- a/archive.R
+++ b/archive.R
@@ -51,7 +51,7 @@ git2r::tag(repo, as.character(new_ver), paste("v", new_ver, sep=""))
 
 # Don't try to push the changes and create a release when changes are part of
 # a pull request.
-if (pull_request != 'false'){
+if (pull_request == 'false'){
   git2r::push(repo,
               name = "deploy",
               refspec = "refs/heads/master",

--- a/archive.R
+++ b/archive.R
@@ -46,12 +46,11 @@ git2r::commit(repo, message = commit_message)
 # Create a new release to trigger Zenodo archiving
 
 github_token = Sys.getenv("GITHUB_TOKEN")
-pull_request = Sys.getenv("TRAVIS_PULL_REQUEST")
 git2r::tag(repo, as.character(new_ver), paste("v", new_ver, sep=""))
-
-system("git remote add deploytags https://${GITHUB_TOKEN}@github.com/weecology/PortalData.git > /dev/null 2>&1")
-system("git push --quiet deploytags master > /dev/null 2>&1", intern = TRUE)
-system("git push --quiet deploytags --tags > /dev/null 2>&1", intern = TRUE)
+git2r::push(repo,
+            name = "deploy",
+            refspec = paste("refs/tags/", new_ver, sep=""),
+            credentials = cred)
 api_release_url = paste("https://api.github.com/repos/", config$repo, "/releases", sep = "")
 httr::POST(url = api_release_url,
            httr::content_type_json(),

--- a/archive.R
+++ b/archive.R
@@ -46,13 +46,19 @@ git2r::commit(repo, message = commit_message)
 # Create a new release to trigger Zenodo archiving
 
 github_token = Sys.getenv("GITHUB_TOKEN")
+pull_request = Sys.getenv("TRAVIS_PULL_REQUEST")
 git2r::tag(repo, as.character(new_ver), paste("v", new_ver, sep=""))
-git2r::push(repo,
+
+# Don't try to push the changes and create a release when changes are part of
+# a pull request.
+if (pull_request != 'false'){
+  git2r::push(repo,
             name = "deploy",
             refspec = paste("refs/tags/", new_ver, sep=""),
             credentials = cred)
-api_release_url = paste("https://api.github.com/repos/", config$repo, "/releases", sep = "")
-httr::POST(url = api_release_url,
-           httr::content_type_json(),
-           httr::add_headers(Authorization = paste("token", github_token)),
-           body = paste('{"tag_name":"', new_ver, '"}', sep=''))
+  api_release_url = paste("https://api.github.com/repos/", config$repo, "/releases", sep = "")
+  httr::POST(url = api_release_url,
+            httr::content_type_json(),
+            httr::add_headers(Authorization = paste("token", github_token)),
+            body = paste('{"tag_name":"', new_ver, '"}', sep=''))
+}

--- a/archive.R
+++ b/archive.R
@@ -53,9 +53,13 @@ git2r::tag(repo, as.character(new_ver), paste("v", new_ver, sep=""))
 # a pull request.
 if (pull_request != 'false'){
   git2r::push(repo,
-            name = "deploy",
-            refspec = paste("refs/tags/", new_ver, sep=""),
-            credentials = cred)
+              name = "deploy",
+              refspec = "refs/heads/master",
+              credentials = cred)
+  git2r::push(repo,
+              name = "deploy",
+              refspec = paste("refs/tags/", new_ver, sep=""),
+              credentials = cred)
   api_release_url = paste("https://api.github.com/repos/", config$repo, "/releases", sep = "")
   httr::POST(url = api_release_url,
             httr::content_type_json(),


### PR DESCRIPTION
1. Make sure that we are testing changes to `archive.R` in pull requests
2. Return to using git2r for all git steps
3. Don't attempt to push changes and make releases on PRs

These interrelated issues were all tied to git2r failing with shallow clones. This has now been fixed allowing
this group of issues to be addressed. 

