### PR TITLE
allow retention of NA period entries in newmoon table [no version bump]

### DIFF
--- a/DataCleaningScripts/new_moon_numbers.r
+++ b/DataCleaningScripts/new_moon_numbers.r
@@ -94,6 +94,7 @@ update_moon_dates = function() {
     #Only keep newmoon dates up to latest census
     
     newmoons=newmoons %>% subset(period <= max(abs(newmoons$period),na.rm=TRUE))
+    newmoons=newmoons %>% subset(period <= max(abs(newmoons$period),na.rm=TRUE) | is.na(period))
     
       #append all new rows to moon_dates data frame
       moon_dates=bind_rows(moon_dates,newmoons)

--- a/DataCleaningScripts/new_moon_numbers.r
+++ b/DataCleaningScripts/new_moon_numbers.r
@@ -90,10 +90,10 @@ update_moon_dates = function() {
       newmoons$censusdate[newdate]=newperiod_dates$censusdate[i]
       newmoons$period[newdate]=newperiod_dates$period[i]
         }
+    }
     
     #Only keep newmoon dates up to latest census
     
-    newmoons=newmoons %>% subset(period <= max(abs(newmoons$period),na.rm=TRUE))
     newmoons=newmoons %>% subset(period <= max(abs(newmoons$period),na.rm=TRUE) | is.na(period))
     
       #append all new rows to moon_dates data frame

--- a/DataCleaningScripts/new_moon_numbers.r
+++ b/DataCleaningScripts/new_moon_numbers.r
@@ -89,7 +89,6 @@ update_moon_dates = function() {
       newdate=which(newmoons$newmoondate==closest)
       newmoons$censusdate[newdate]=newperiod_dates$censusdate[i]
       newmoons$period[newdate]=newperiod_dates$period[i]
-        }
     }
     
     #Only keep newmoon dates up to latest census


### PR DESCRIPTION
previously, when a newmoon did not have an associated survey, it was not added to the newmoons table
this is a simple fix to allow newmoons that have NA entries for the period number to be retained in the resulting newmoons table