### PR TITLE
Increase chance of successful weather download

### DIFF
--- a/DataCleaningScripts/weather_server_update.py
+++ b/DataCleaningScripts/weather_server_update.py
@@ -36,8 +36,9 @@ weather_url = 'http://166.153.133.121/?command=TableDisplay&table=MET&records=20
 storms_url = 'http://166.153.133.121/?command=TableDisplay&table=Storms&records=200'
 
 r_weather = requests.get(weather_url, allow_redirects=True)
-r_storms = requests.get(storms_url, allow_redirects=True)
 open('weather-data.html', 'wb').write(r_weather.content)
-open('storms-data.html', 'wb').write(r_storms.content)
 shutil.copyfile('weather-data.html', '/var/www/html/weather-data.html')
+
+r_storms = requests.get(storms_url, allow_redirects=True)
+open('storms-data.html', 'wb').write(r_storms.content)
 shutil.copyfile('storms-data.html', '/var/www/html/storms-data.html')

--- a/DataCleaningScripts/weather_server_update.py
+++ b/DataCleaningScripts/weather_server_update.py
@@ -33,7 +33,7 @@ if os.path.exists('storms-data.html'):
     os.remove('storms-data.html')
 
 weather_url = 'http://166.153.133.121/?command=TableDisplay&table=MET&records=200'
-storms_url = 'http://166.153.133.121/?command=TableDisplay&table=Storms&records=200'
+storms_url = 'http://166.153.133.121/?command=TableDisplay&table=Storms&records=1650'
 
 r_weather = requests.get(weather_url, allow_redirects=True)
 open('weather-data.html', 'wb').write(r_weather.content)

--- a/DataCleaningScripts/weather_server_update.py
+++ b/DataCleaningScripts/weather_server_update.py
@@ -32,8 +32,8 @@ if os.path.exists('weather-data.html'):
 if os.path.exists('storms-data.html'):
     os.remove('storms-data.html')
 
-weather_url = 'http://166.153.133.121/?command=TableDisplay&table=MET&records=1000'
-storms_url = 'http://166.153.133.121/?command=TableDisplay&table=Storms&records=2500'
+weather_url = 'http://166.153.133.121/?command=TableDisplay&table=MET&records=200'
+storms_url = 'http://166.153.133.121/?command=TableDisplay&table=Storms&records=200'
 
 r_weather = requests.get(weather_url, allow_redirects=True)
 r_storms = requests.get(storms_url, allow_redirects=True)


### PR DESCRIPTION
We've been experiencing ongoing issues with the connection to the weather station timing out.
This attempts to fix this by: 1) Downloading less data at a time. 200 hours is > the 1 week of data we need
from the weather and 1650 is > the largest number of values in the storms table seen in a week; 2) Run the
downloads sequentially. We were effectively doing both downloads at once, which is more likely to
overwhelm the modem. This change completes the weather download before starting the storms download.