### PR TITLE
Reduce Travis notifications to Slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,9 @@ script:
   - Rscript archive.R
 
 notifications:
-  slack: weecology:CwWehNkftf60m2nc1LN7QMqx
-
-after_success:
-slack:
-  if: branch = master
-  on_success: change
-  on_failure: change
-      
+  slack:
+    rooms: weecology:CwWehNkftf60m2nc1LN7QMqx
+    if: branch = master
+    on_pull_requests: false
+    on_success: never
+    on_failure: always


### PR DESCRIPTION
Reduce messages to only the master branch and only changes in failure status. Never report success.

Previous attempts due to a combination of being in `after_success` and the need to
separate out the Slack name and token into `rooms` for more complex builds
(I think).