### PR TITLE
Automatically fill weather gaps [no version bump]

### DIFF
--- a/DataCleaningScripts/new_weather_data.R
+++ b/DataCleaningScripts/new_weather_data.R
@@ -36,11 +36,12 @@ new_met_data <- function() {
 #   `colnames<-`(header_storms) %>%
 #   dplyr::rename(precipitation=Rain_mm_Tot,timestamp=TIMESTAMP,record=RECORD,battv=BattV_Min)
   
-# Pull raw data (latest week of records, plus some overlap for saftey) & rename columns
+today <- lubridate::ymd_hms(gsub(":\\d+:\\d+",":00:00",Sys.time()))
+  # Pull raw data (latest week of records, plus some overlap for saftey) & rename columns
   message("Pulling raw weather data")
 
-rawdata = htmltab::htmltab(doc='http://157.230.136.69/weather-data.html', sep = "")  %>%
-
+rawdata <- suppressMessages(htmltab::htmltab(doc='http://157.230.136.69/weather-data.html', sep = "", 
+                                             which = 1)) %>%
   dplyr::rename(airtemp=AirTC_Avg,precipitation=Rain_mm_Tot,timestamp=TimeStamp,record=Record,battv=BattV)
 
   message("Raw weather data loaded")
@@ -48,8 +49,8 @@ rawdata = htmltab::htmltab(doc='http://157.230.136.69/weather-data.html', sep = 
 # Pull raw storms data (latest 2500 records) & rename columns
 message("Pulling raw storms data")
 
-stormsnew = htmltab::htmltab(doc="http://157.230.136.69/storms-data.html", sep = "")  %>%
- 
+stormsnew <- suppressMessages(htmltab::htmltab(doc="http://157.230.136.69/storms-data.html", sep = "", 
+                                               which = 1)) %>%
   dplyr::rename(timestamp = TimeStamp, record = Record, battv = BattV_Min, precipitation = Rain_mm_Tot)
 
   message("Raw storms data loaded")
@@ -78,18 +79,39 @@ class(stormsnew$record)="numeric"
 class(stormsnew$battv)="numeric"
 class(stormsnew$precipitation)="numeric"
 
-# Load existing data for comparison
-weather=read.csv("Weather/Portal_weather.csv")
-  weather$timestamp = lubridate::ymd_hms(weather$timestamp)
+# New weather table
+weather <- read.csv("Weather/Portal_weather.csv") 
+weather$timestamp <- lubridate::ymd_hms(weather$timestamp)
+last_date <- max(weather$timestamp)
+weather <- weather %>%
+  dplyr::add_row(timestamp = lubridate::ymd_hms(seq.POSIXt(last_date+3600, today, by = "1 hour")),
+         year = lubridate::year(timestamp), month = lubridate::month(timestamp),
+         day = lubridate::day(timestamp), hour = 100*lubridate::hour(timestamp))
+weather$day[weather$hour==0] = weather$day[which(weather$hour==0)-1]
+weather$month[weather$hour==0] = weather$month[which(weather$hour==0)-1]
+weather$year[weather$hour==0] = weather$year[which(weather$hour==0)-1]
+weather$hour[weather$hour==0] = 2400
 
-storms=read.csv("Weather/Portal_storms.csv")
-  storms$timestamp = lubridate::ymd_hms(storms$timestamp)
+newdata <- suppressMessages(coalesce_join(weather, rawdata, 
+                                          by = c("year", "month", "day", "hour", "timestamp")))
 
-#Keep only new data
-newdata=rawdata[rawdata$timestamp>tail(weather$timestamp,n=1),]
-stormsnew=stormsnew[stormsnew$timestamp>tail(storms$timestamp,n=1),]
+# New storms table
+storms <- read.csv("Weather/Portal_storms.csv")
+  storms$timestamp <- lubridate::ymd_hms(storms$timestamp)
+  # Keep only new data
+  
+  stormsnew <- stormsnew[stormsnew$timestamp>tail(storms$timestamp,n=1),]
 
-return(list(newdata,weather,stormsnew,storms))
+# New overlap table
+overlap <- read.csv("Weather/Portal_weather_overlap.csv") 
+overlap$timestamp <- lubridate::ymd_hms(overlap$timestamp)
+last_overlap <- max(overlap$timestamp)
+
+newoverlap <- newdata %>% 
+  dplyr::filter(timestamp > last_overlap) %>%
+  dplyr::select(year,month,day,hour,timestamp,record,battv,airtemp,precipitation,RH)
+
+return(list(newdata,stormsnew,newoverlap))
 
 }
 
@@ -104,22 +126,50 @@ return(list(newdata,weather,stormsnew,storms))
 
 append_weather <- function() {
 
-  data=new_met_data()
+  data <- new_met_data()
 
 # append new data
 write.table(data[1], file = "Weather/Portal_weather.csv",
-            row.names = FALSE, col.names = FALSE, na = "", append = TRUE, sep = ",")
+            row.names = FALSE, col.names = TRUE, na = "", sep = ",")
 
-  write.table(data[3], file = "Weather/Portal_storms.csv",
+write.table(data[2], file = "Weather/Portal_storms.csv",
               row.names = FALSE, col.names = FALSE, na = "", append = TRUE, sep = ",")
 
 # also append new data to overlap file
-overlap=as.data.frame(data[1]) %>% 
-  dplyr::select(year,month,day,hour,timestamp,record,battv,airtemp,precipitation,RH)
-overlap$timestamp=lubridate::ymd_hms(overlap$timestamp)
-write.table(overlap, file = "Weather/Portal_weather_overlap.csv",
+write.table(data[3], file = "Weather/Portal_weather_overlap.csv",
             row.names = FALSE, col.names = FALSE, na = "", append = TRUE, sep = ",")
 
 }
 
+#' Full_join in dplyr, but with coalesce 
+#' Replace NAs with values where available automatically in table join
+#' via https://alistaire.rbind.io/blog/coalescing-joins/
+#'
+#'
+#' @example coalesce_join()
+#'
 
+coalesce_join <- function(x, y, 
+                          by = NULL, suffix = c(".x", ".y"), 
+                          join = dplyr::full_join, ...) {
+  joined <- join(x, y, by = by, suffix = suffix, ...)
+  # names of desired output
+  cols <- union(names(x), names(y))
+  
+  to_coalesce <- names(joined)[!names(joined) %in% cols]
+  suffix_used <- suffix[ifelse(endsWith(to_coalesce, suffix[1]), 1, 2)]
+  # remove suffixes and de-duplicate
+  to_coalesce <- unique(substr(
+    to_coalesce, 
+    1, 
+    nchar(to_coalesce) - nchar(suffix_used)
+  ))
+  
+  coalesced <- purrr::map_dfc(to_coalesce, ~dplyr::coalesce(
+    joined[[paste0(.x, suffix[1])]], 
+    joined[[paste0(.x, suffix[2])]]
+  ))
+  names(coalesced) <- to_coalesce
+  
+  dplyr::bind_cols(joined, coalesced)[cols]
+}


### PR DESCRIPTION
Add hourly weather rows up to present, regardless of data. Missing data will be filled in as available via `coalesce_join`.