### PR TITLE
Warn contributors about PRs from forks in tests [no version bump]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,11 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
+      - name: Tests will fail on PRs from forks
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo Tests require pull requests be submitted from branches in the main repository
+          exit 1 
       - uses: actions/checkout@v4
         with:
             fetch-depth: 3


### PR DESCRIPTION
Due to the use of secrets in tests will not pass if submitted via PRs from forks. These failures can be quite confusing.
To reduce confusion this adds up step to the GH actions workflow that will fail informatively if running on a PR from a fork.